### PR TITLE
Inner class 스키마 이름 지정하도록 수정

### DIFF
--- a/application-external-api/src/main/java/com/gogonew/api/goal/GoalDto.java
+++ b/application-external-api/src/main/java/com/gogonew/api/goal/GoalDto.java
@@ -21,7 +21,7 @@ public class GoalDto {
 
     @Getter
     @Setter
-    @Schema
+    @Schema(name = "GoalCreateDto")
     @NoArgsConstructor
     public static class Create {
         @ValidUuid

--- a/application-external-api/src/main/java/com/gogonew/api/pocket/PocketDto.java
+++ b/application-external-api/src/main/java/com/gogonew/api/pocket/PocketDto.java
@@ -27,7 +27,7 @@ public class PocketDto {
 
     @Getter
     @Setter
-    @Schema
+    @Schema(name = "PocketCreateDto")
     @NoArgsConstructor
     public static class Create {
         @ValidUuid(message = "roomId는 UUID 형태로 입력해주세요")

--- a/application-external-api/src/main/java/com/gogonew/api/room/RoomDto.java
+++ b/application-external-api/src/main/java/com/gogonew/api/room/RoomDto.java
@@ -24,6 +24,7 @@ public class RoomDto {
 
     @Getter
     @AllArgsConstructor
+    @Schema(name = "RoomCreateDto")
     @NoArgsConstructor // Spring이 파라미터에서 생성하기 위해 필요
     public static class Create {
         @NotBlank(message = "방 제목을 작성해주세요.")


### PR DESCRIPTION
## 작업내용
- <img width="600" alt="image" src="https://user-images.githubusercontent.com/76721493/221219558-b1f761bd-12f2-4244-97b9-de1cf177b304.png">
- 프로젝트에서 Dto를 Inner class 로 관리 
- Inner class 의 경우 레퍼런스에 `$` 가 추가되는데. Spring Rest docs 에서 스키마 자동생성시 이 레퍼런스를 그대로 포함.
- Typescript 에서 swagger schema 기반 인터페이스 생성시 `$` 가 파싱 안되는 오류 발생

<br>

## 오류해결
- `@Schema` 어노테이션에 CreateDto의 스키마 이름 넘겨주도록 수정
- [참고문서](https://stackoverflow.com/questions/65284116/swagger-2-0-how-to-solve-same-response-class-names-in-different-packages-issue)

